### PR TITLE
Add references for ED

### DIFF
--- a/Heisenberg/chain_20_O.md
+++ b/Heisenberg/chain_20_O.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma    | Energy Variance | DOF | Einf | Method                                | Reference |
 |--------------------|----------|-----------------|-----|------|---------------------------------------|-----------|
-| -34.72989333759587 | 0        | 0               | 20  | 0    | Exact diagonalization                 | TODO: own code (ED) |
+| -34.72989333759587 | 0        | 0               | 20  | 0    | Exact diagonalization                 | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/chain_20_O/ed_netket.sh) |
 | -34.729829         | 0.000014 | 0.000506        | 20  | 0    | RNN                                   | TODO: own code (RNN) |
 | -34.7298933375     |          | 6.3E-10         | 20  | 0    | DMRG (max truncation error ~ 1.0E-12) | TODO: ask Max |
 | -34.72711          | 0.00021  | 0.04559541      | 20  | 0    | RBM (alpha = 1)                       | TODO: own code (RBM) |

--- a/Heisenberg/chain_20_P.md
+++ b/Heisenberg/chain_20_P.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma     | Energy Variance | DOF | Einf | Method                                | Reference |
 |--------------------|-----------|-----------------|-----|------|---------------------------------------|-----------|
-| -35.61754611950579 | 0         | 0               | 20  | 0    | Exact diagonalization                 | TODO: own code (ED) |
+| -35.61754611950579 | 0         | 0               | 20  | 0    | Exact diagonalization                 | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/chain_20_P/ed_netket.sh) |
 | -35.6174890        | 0.0000072 | 0.0001278       | 20  | 0    | RNN                                   | TODO: own code (RNN) |
 | -35.6175098        | 0.0000046 | 0.0000534       | 20  | 0    | RNN + translational symmetry          | TODO: own code (RNN) |
 | -35.61452          | 0.00033   | 0.0488          | 20  | 0    | VMC with projected fermions + Jastrow | TODO: ask Francesco |

--- a/Heisenberg/kagome-2x3_18_P.md
+++ b/Heisenberg/kagome-2x3_18_P.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma | Energy Variance | DOF | Einf | Method                                  | Reference |
 |--------------------|-------|-----------------|-----|------|-----------------------------------------|-----------|
-| -32.19308309416487 |       |                 | 18  | 0    | Exact Diagonalization                   | TODO: own code (ED) |
+| -32.19308309416487 |       |                 | 18  | 0    | Exact Diagonalization                   | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/kagome-2x3_18_P/ed_netket.sh) |
 | -32.1645862        |       | 1.20            | 18  | 0    | VQE (SR + symm. + 108 variational pars) | TODO: ask Nikita |
 | -32.19308309416483 |       | 1e-14           | 18  | 0    | DMRG (bond dimension = 368)             | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/kagome-2x3_18_P/dmrg.sh) |
 | -29.1114           | 0.0032 | 10.5339        | 18  | 0    | Jastrow baseline                        | TODO: own code (RBM) |

--- a/Heisenberg/square_36_O.md
+++ b/Heisenberg/square_36_O.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance        | DOF | Einf | Method                       | Reference |
 |--------------------|--------|------------------------|-----|------|------------------------------|-----------|
-| -86.9071441699763  |        |                        | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -86.9071441699763  |        |                        | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/square_36_O/ed_lattice_symmetries.sh) |
 | -86.90713263791655 |        | 0.00045932030843687244 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/square_36_O/dmrg.sh) |
 | -85.4857           | 0.0035 | 12.2737                | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -85.6567           | 0.0036 | 13.4570                | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/Heisenberg/square_36_P.md
+++ b/Heisenberg/square_36_P.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance   | DOF | Einf | Method                       | Reference |
 |--------------------|--------|-------------------|-----|------|------------------------------|-----------|
-| -97.7575895972357  |        |                   | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -97.7575895972357  |        |                   | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/square_36_P/ed_lattice_symmetries.sh) |
 | -97.72162414290578 |        | 1.385137434483113 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/square_36_P/dmrg.sh) |
 | -96.2702           | 0.0037 | 13.9167           | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -96.4427           | 0.0038 | 14.7488           | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/Heisenberg/triangular_16_P.md
+++ b/Heisenberg/triangular_16_P.md
@@ -1,6 +1,6 @@
 | Energy              | Sigma  | Energy Variance | DOF | Einf | Method                      | Reference |
 |---------------------|--------|-----------------|-----|------|-----------------------------|-----------|
-| -34.22205967006502  | 0      | 0               | 16  | 0    | Exact diagonalization       | TODO: own code (ED) |
+| -34.22205967006502  | 0      | 0               | 16  | 0    | Exact diagonalization       | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/triangular_16_P/ed_netket.sh) |
 | -34.1780764         | 0      | 0.424225        | 16  | 0    | VQE (SR + symm. + 64 par)   | TODO: ask Nikita |
 | -34.222059670065036 |        | 1e-15           | 16  | 0    | DMRG (bond dimension = 256) | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/triangular_16_P/dmrg.sh) |
 | -33.5469            | 0.0034 | 12.0932         | 16  | 0    | RBM (alpha = 1)             | TODO: own code (RBM) |

--- a/Heisenberg/triangular_36_P.md
+++ b/Heisenberg/triangular_36_P.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance   | DOF | Einf | Method                       | Reference |
 |--------------------|--------|-------------------|-----|------|------------------------------|-----------|
-| -80.6937689612426  |        |                   | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -80.6937689612426  |        |                   | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/triangular_36_P/ed_lattice_symmetries.sh) |
 | -80.36672248793934 |        | 7.068731007373572 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/Heisenberg/triangular_36_P/dmrg.sh) |
 | -70.7915           | 0.0065 | 43.4753           | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -70.0967           | 0.0060 | 37.0349           | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/Hubbard/chain_14_P_4_1.66810054.md
+++ b/Hubbard/chain_14_P_4_1.66810054.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                                                       | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------------------------------------------|-----------|
-| -12.26614969817052092 |       |                 | 8   | 1.906400617142857 | Exact diagonalization                                        | TODO: own code (ED) |
+| -12.26614969817052092 |       |                 | 8   | 1.906400617142857 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_1.66810054/ed_netket.sh) |
 | -12.266149670         |       | 3.42e-8         | 8   | 1.906400617142857 | DMRG (maxbonddim = 1550, extrapolated energy -12.266149729 +/- 5E-8) | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_1.md
+++ b/Hubbard/chain_14_P_4_1.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                                                       | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------------------------------------------|-----------|
-| -12.76282278586950625 |       |                 | 8   | 1.142857142857143 | Exact diagonalization                                        | TODO: own code (ED) |
+| -12.76282278586950625 |       |                 | 8   | 1.142857142857143 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_1/ed_netket.sh) |
 | -12.76281             |       | 4.643e-6        | 8   | 1.142857142857143 | DMRG (MaxBondDim = 1550, Extrap Energy = -12.762823 +/- 2.e-6) | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_10.md
+++ b/Hubbard/chain_14_P_4_10.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                                                      | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|-------------------------------------------------------------|-----------|
-| -9.945093959690886720 |       |                 | 8   | 11.42857142857143 | Exact diagonalization                                       | TODO: own code (ED) |
+| -9.945093959690886720 |       |                 | 8   | 11.42857142857143 | Exact diagonalization                                       | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_10/ed_netket.sh) |
 | -9.945092             |       | 9.77e-7         | 8   | 11.42857142857143 | DMRG (MaxBondDim ~1500, Extrap Eng = -9.9450941 +/- 2.9e-7) | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_2.15443469.md
+++ b/Hubbard/chain_14_P_4_2.15443469.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------|-----------|
-| -11.95919775515623762 |       |                 | 8   | 2.462211074285714 | Exact diagonalization    | TODO: own code (ED) |
+| -11.95919775515623762 |       |                 | 8   | 2.462211074285714 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_2.15443469/ed_netket.sh) |
 | -11.959197754         |       | 9.9e-10         | 8   | 2.462211074285714 | DMRG (MaxBondDim ~1500)  | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_2.7825594.md
+++ b/Hubbard/chain_14_P_4_2.7825594.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------|-----------|
-| -11.62004487734578539 |       |                 | 8   | 3.180067885714286 | Exact diagonalization    | TODO: own code (ED) |
+| -11.62004487734578539 |       |                 | 8   | 3.180067885714286 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_2.7825594/ed_netket.sh) |
 | -11.6200448772        |       | 2.0e-10         | 8   | 3.180067885714286 | DMRG (MaxBondDim ~1500)  | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_3.59381366.md
+++ b/Hubbard/chain_14_P_4_3.59381366.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------|-----------|
-| -11.26052241060044068 |       |                 | 8   | 4.107215611428571 | Exact diagonalization    | TODO: own code (ED) |
+| -11.26052241060044068 |       |                 | 8   | 4.107215611428571 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_3.59381366/ed_netket.sh) |
 | -11.260522410599773   |       | 1.5e-12         | 8   | 4.107215611428571 | DMRG (MaxBondDim ~1500)  | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_4.64158882.md
+++ b/Hubbard/chain_14_P_4_4.64158882.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------|-----------|
-| -10.89695798483333711 |       |                 | 8   | 5.304672937142857 | Exact diagonalization    | TODO: own code (ED) |
+| -10.89695798483333711 |       |                 | 8   | 5.304672937142857 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_4.64158882/ed_netket.sh) |
 | -10.896957987         |       | 8.2e-12         | 8   | 5.304672937142857 | DMRG (MaxBondDim ~1500)  | TODO: ask Max |

--- a/Hubbard/chain_14_P_4_7.74263683.md
+++ b/Hubbard/chain_14_P_4_7.74263683.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf              | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------------------|--------------------------|-----------|
-| -10.22660390523532392 |       |                 | 8   | 8.848727805714287 | Exact diagonalization    | TODO: own code (ED) |
+| -10.22660390523532392 |       |                 | 8   | 8.848727805714287 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/chain_14_P_4_7.74263683/ed_netket.sh) |
 | -10.226603848         |       | 7.67e-8         | 8   | 8.848727805714287 | DMRG (MaxBondDim ~1500)  | TODO: ask Max |

--- a/Hubbard/square_16_P_4_10.md
+++ b/Hubbard/square_16_P_4_10.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma  | Energy Variance | DOF | Einf | Method                                                       | Reference |
 |-----------------------|--------|-----------------|-----|------|--------------------------------------------------------------|-----------|
-| -16.14320817020241350 |        |                 | 8   | 10   | Exact diagonalization                                        | TODO: own code (ED) |
+| -16.14320817020241350 |        |                 | 8   | 10   | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_10/ed_lattice_symmetries.sh) |
 | -16.1383              | 0.0001 | 0.078(3)        | 8   | 10   | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 8. Single hidden layer fully connected net with alpha = 32) | TODO: ask Javier |
 | -16.14320807          |        | 1.81e-7         | 8   | 10   | DMRG (MaxBondDim = 3200)                                     | TODO: ask Max |

--- a/Hubbard/square_16_P_4_2.md
+++ b/Hubbard/square_16_P_4_2.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|------|--------------------------|-----------|
-| -18.49543661946073669 |       |                 | 8   | 2    | Exact diagonalization    | TODO: own code (ED) |
+| -18.49543661946073669 |       |                 | 8   | 2    | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_2/ed_lattice_symmetries.sh) |
 | -18.495436027         |       | 2.067e-7        | 8   | 2    | DMRG (MaxLinkDim ~ 3200) | TODO: ask Max |

--- a/Hubbard/square_16_P_4_3.5981.md
+++ b/Hubbard/square_16_P_4_3.5981.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma   | Energy Variance | DOF | Einf   | Method                                                       | Reference |
 |-----------------------|---------|-----------------|-----|--------|--------------------------------------------------------------|-----------|
-| -17.69803001870206671 |         |                 | 8   | 3.5981 | Exact diagonalization                                        | TODO: own code (ED) |
+| -17.69803001870206671 |         |                 | 8   | 3.5981 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_3.5981/ed_lattice_symmetries.sh) |
 | -17.69357             | 0.00004 | 0.033(2)        | 8   | 3.5981 | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 8. Single hidden layer fully connected net with alpha = 32) | TODO: ask Javier |
 | -17.69623             |         | 2.09e-6         | 8   | 3.5981 | DMRG (MaxBondDim ~3200)                                      | TODO: ask Max |

--- a/Hubbard/square_16_P_4_4.md
+++ b/Hubbard/square_16_P_4_4.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|------|--------------------------|-----------|
-| -17.53489779664119652 |       |                 | 8   | 4    | Exact diagonalization    | TODO: own code (ED) |
+| -17.53489779664119652 |       |                 | 8   | 4    | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_4/ed_lattice_symmetries.sh) |
 | -17.534896636         |       | 1.070e-6        | 8   | 4    | DMRG (MaxBondDim ~ 3200) | TODO: ask Max |

--- a/Hubbard/square_16_P_4_6.md
+++ b/Hubbard/square_16_P_4_6.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|------|--------------------------|-----------|
-| -16.89992663097499559 |       |                 | 8   | 6    | Exact diagonalization    | TODO: own code (ED) |
+| -16.89992663097499559 |       |                 | 8   | 6    | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_6/ed_lattice_symmetries.sh) |
 | -16.899926454         |       | 1.9047e-7       | 8   | 6    | DMRG (MaxBondDim ~ 3200) | TODO: ask Max |

--- a/Hubbard/square_16_P_4_7.74264.md
+++ b/Hubbard/square_16_P_4_7.74264.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma  | Energy Variance | DOF | Einf    | Method                                                       | Reference |
 |-----------------------|--------|-----------------|-----|---------|--------------------------------------------------------------|-----------|
-| -16.50915482526514211 |        |                 | 8   | 7.74264 | Exact diagonalization                                        | TODO: own code (ED) |
+| -16.50915482526514211 |        |                 | 8   | 7.74264 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_7.74264/ed_lattice_symmetries.sh) |
 | -16.505               | 0.0001 | 0.055(1)        | 8   | 7.74264 | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 8. Single hidden layer fully connected net with alpha = 32) | TODO: ask Javier |
 | -16.5091541           |        | 1.331e-7        | 8   | 7.74264 | DMRG (MaxBondDim ~3200)                                      | TODO: ask Max |

--- a/Hubbard/square_16_P_4_8.md
+++ b/Hubbard/square_16_P_4_8.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|------|--------------------------|-----------|
-| -16.46062675368177963 |       |                 | 8   | 8    | Exact diagonalization    | TODO: own code (ED) |
+| -16.46062675368177963 |       |                 | 8   | 8    | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_4_8/ed_lattice_symmetries.sh) |
 | -16.460626633         |       | 1.6764e-7       | 8   | 8    | DMRG (MaxBondDim ~ 3200) | TODO: ask Max |

--- a/Hubbard/square_16_P_5_10.md
+++ b/Hubbard/square_16_P_5_10.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma   | Energy Variance | DOF | Einf   | Method                                                       | Reference |
 |-----------------------|---------|-----------------|-----|--------|--------------------------------------------------------------|-----------|
-| -16.90355998424354667 |         |                 | 10  | 15.625 | Exact diagonalization                                        | TODO: own code (ED) |
+| -16.90355998424354667 |         |                 | 10  | 15.625 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_10/ed_lattice_symmetries.sh) |
 | -16.90183             | 0.00002 | 0.047(1)        | 10  | 15.625 | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 10. Single hidden layer fully connected net with alpha = 64). C4 and K = 0 projections | TODO: ask Javier |
 | -16.903559816         |         | 5.71e-6         | 10  | 15.625 | DMRG (MaxBondDim = 7000)                                     | TODO: ask Max |

--- a/Hubbard/square_16_P_5_2.1544.md
+++ b/Hubbard/square_16_P_5_2.1544.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma    | Energy Variance | DOF | Einf    | Method                                                       | Reference |
 |-----------------------|----------|-----------------|-----|---------|--------------------------------------------------------------|-----------|
-| -21.21223577699910834 |          |                 | 10  | 3.36625 | Exact diagonalization                                        | TODO: own code (ED) |
+| -21.21223577699910834 |          |                 | 10  | 3.36625 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_2.1544/ed_lattice_symmetries.sh) |
 | -21.211896            | 0.000002 | 0.027(4)        | 10  | 3.36625 | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 10. Single hidden layer fully connected net with alpha = 64). C4 and K = 0 projections | TODO: ask Javier |
 | -21.2122722           |          | 2.61e-8         | 10  | 3.36625 | DMRG (MaxBondDim 7000)                                       | TODO: ask Max |

--- a/Hubbard/square_16_P_5_2.md
+++ b/Hubbard/square_16_P_5_2.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf  | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------|--------------------------|-----------|
-| -21.37695098445833608 |       |                 | 10  | 3.125 | Exact diagonalization    | TODO: own code (ED) |
+| -21.37695098445833608 |       |                 | 10  | 3.125 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_2/ed_lattice_symmetries.sh) |
 | -21.37695098375       |       | 1.84e-8         | 10  | 3.125 | DMRG (MaxBondDim = 7000) | TODO: ask Max |

--- a/Hubbard/square_16_P_5_3.5981.md
+++ b/Hubbard/square_16_P_5_3.5981.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma    | Energy Variance | DOF | Einf       | Method                                                       | Reference |
 |-----------------------|----------|-----------------|-----|------------|--------------------------------------------------------------|-----------|
-| -19.89163719994867208 |          |                 | 10  | 5.62203125 | Exact diagonalization                                        | TODO: own code (ED) |
+| -19.89163719994867208 |          |                 | 10  | 5.62203125 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_3.5981/ed_lattice_symmetries.sh) |
 | -19.890443            | 0.000006 | 0.031(3)        | 10  | 5.62203125 | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 10. Single hidden layer fully connected net with alpha = 64). C4 and K = 0 projections | TODO: ask Javier |
 | -19.88822918          |          | 2.920e-7        | 10  | 5.62203125 | DMRG (MaxBondDim = 7000)                                     | TODO: ask Max |

--- a/Hubbard/square_16_P_5_4.md
+++ b/Hubbard/square_16_P_5_4.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|------|--------------------------|-----------|
-| -19.58093752541909538 |       |                 | 10  | 6.25 | Exact diagonalization    | TODO: own code (ED) |
+| -19.58093752541909538 |       |                 | 10  | 6.25 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_4/ed_lattice_symmetries.sh) |
 | -19.58093750854       |       | 4.53e-7         | 10  | 6.25 | DMRG (MaxBondDim = 7000) | TODO: ask Max |

--- a/Hubbard/square_16_P_5_6.md
+++ b/Hubbard/square_16_P_5_6.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf  | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|-------|--------------------------|-----------|
-| -18.35836507445482724 |       |                 | 10  | 9.375 | Exact diagonalization    | TODO: own code (ED) |
+| -18.35836507445482724 |       |                 | 10  | 9.375 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_6/ed_lattice_symmetries.sh) |
 | -18.3583650105        |       |                 | 10  | 9.375 | DMRG (MaxBondDim = 7000) | TODO: ask Max |

--- a/Hubbard/square_16_P_5_7.74264.md
+++ b/Hubbard/square_16_P_5_7.74264.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma   | Energy Variance | DOF | Einf      | Method                                                       | Reference |
 |-----------------------|---------|-----------------|-----|-----------|--------------------------------------------------------------|-----------|
-| -17.60373155517908828 |         |                 | 10  | 12.097875 | Exact diagonalization                                        | TODO: own code (ED) |
+| -17.60373155517908828 |         |                 | 10  | 12.097875 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_7.74264/ed_lattice_symmetries.sh) |
 | -17.60200             | 0.00001 | 0.037(4)        | 10  | 12.097875 | VMC Hidden Fermion Determinant State Ansatz (N_hidden = 10. Single hidden layer fully connected net with alpha = 64). C4 and K = 0 projections | TODO: ask Javier |
 | -17.6037303           |         | 3.5781e-6       | 10  | 12.097875 | DMRG (MaxBondDim = 7000)                                     | TODO: ask Max |

--- a/Hubbard/square_16_P_5_8.md
+++ b/Hubbard/square_16_P_5_8.md
@@ -1,4 +1,4 @@
 | Energy                | Sigma | Energy Variance | DOF | Einf | Method                   | Reference |
 |-----------------------|-------|-----------------|-----|------|--------------------------|-----------|
-| -17.51036669487865893 |       |                 | 10  | 12.5 | Exact diagonalization    | TODO: own code (ED) |
+| -17.51036669487865893 |       |                 | 10  | 12.5 | Exact diagonalization    | [code](https://github.com/varbench/methods/blob/main/scripts/Hubbard/square_16_P_5_8/ed_lattice_symmetries.sh) |
 | -17.510366568         |       | 3.9226e-6       | 10  | 12.5 | DMRG (MaxBondDim = 7000) | TODO: ask Max |

--- a/J1J2/rectangular-4x6_24_P_0.5.md
+++ b/J1J2/rectangular-4x6_24_P_0.5.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma | Energy Variance | DOF | Einf | Method                                                       | Reference |
 |--------------------|-------|-----------------|-----|------|--------------------------------------------------------------|-----------|
-| -50.16239379527527 |       |                 | 24  | 0    | Exact diagonalization                                        | TODO: own code (ED) |
+| -50.16239379527527 |       |                 | 24  | 0    | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/rectangular-4x6_24_P_0.5/ed_lattice_symmetries.sh) |
 | -50.0930476        |       | 0.99            | 24  | 0    | VQE + symm. circuit (96 pars., Ns = 2^14 per par, statevector) | TODO: ask Nikita |
 | -50.1019006        |       | 0.95            | 24  | 0    | VQE + symm. circuit (96 pars., exact grads & metric, statevector) | TODO: ask Nikita |
 | -50.16239379503101 |  | 3.916126117129898e-8 | 24  | 0    | DMRG (bond dimension = 4096)                                 | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/rectangular-4x6_24_P_0.5/dmrg.sh) |

--- a/J1J2/square_16_P_0.05.md
+++ b/J1J2/square_16_P_0.05.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -43.5577625 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -43.5577625 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.05/ed_netket.sh) |
 | -43.556203  |       | 0.0692          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -43.5506897 |       | 0.2979          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.1.md
+++ b/J1J2/square_16_P_0.1.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -42.228299  |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -42.228299  |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.1/ed_netket.sh) |
 | -42.2261272 |       | 0.0949          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -42.2249398 |       | 0.1334          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.15.md
+++ b/J1J2/square_16_P_0.15.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -40.9307425 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -40.9307425 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.15/ed_netket.sh) |
 | -40.9284231 |       | 0.0964          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -40.9286848 |       | 0.0848          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.2.md
+++ b/J1J2/square_16_P_0.2.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -39.6719323 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -39.6719323 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.2/ed_netket.sh) |
 | -39.6712875 |       | 0.0277          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -39.6673167 |       | 0.1663          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.25.md
+++ b/J1J2/square_16_P_0.25.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -38.4610881 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -38.4610881 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.25/ed_netket.sh) |
 | -38.4597245 |       | 0.0487          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -38.4587938 |       | 0.0875          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.3.md
+++ b/J1J2/square_16_P_0.3.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -37.310965  |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -37.310965  |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.3/ed_netket.sh) |
 | -37.3082879 |       | 0.0873          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -37.308939  |       | 0.0624          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.35.md
+++ b/J1J2/square_16_P_0.35.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -36.2396643 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -36.2396643 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.35/ed_netket.sh) |
 | -36.2386253 |       | 0.0336          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -36.2374318 |       | 0.0657          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.4.md
+++ b/J1J2/square_16_P_0.4.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -35.2734575 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -35.2734575 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.4/ed_netket.sh) |
 | -35.2706122 |       | 0.0945          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -35.2712652 |       | 0.0629          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.45.md
+++ b/J1J2/square_16_P_0.45.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -34.4511874 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -34.4511874 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.45/ed_netket.sh) |
 | -34.4497048 |       | 0.0402          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -34.4495635 |       | 0.0442          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.5.md
+++ b/J1J2/square_16_P_0.5.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma   | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |--------------------|---------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -33.83169340557936 |         |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -33.83169340557936 |         |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.5/ed_netket.sh) |
 | -33.8315064        |         | 7e-3            | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -33.83169340557946 |         | 1e-15           | 16  | 0    | DMRG (bond dimension = 256)                             | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.5/dmrg.sh) |
 | -33.0219           | 0.0036  | 12.9877         | 16  | 0    | RBM (alpha = 1)                                         | TODO: own code (RBM) |

--- a/J1J2/square_16_P_0.6.md
+++ b/J1J2/square_16_P_0.6.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -33.6573326 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -33.6573326 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.6/ed_netket.sh) |
 | -33.6522114 |       | 0.1508          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -33.6506415 |       | 0.1589          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.65.md
+++ b/J1J2/square_16_P_0.65.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -34.5204783 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -34.5204783 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.65/ed_netket.sh) |
 | -34.518044  |       | 0.0759          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -34.5012835 |       | 0.4162          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.7.md
+++ b/J1J2/square_16_P_0.7.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -36.0869194 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -36.0869194 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.7/ed_netket.sh) |
 | -36.0809175 |       | 0.1979          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -36.0813809 |       | 0.1482          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.75.md
+++ b/J1J2/square_16_P_0.75.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -38.0334774 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -38.0334774 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.75/ed_netket.sh) |
 | -38.0297699 |       | 0.1407          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -38.0279754 |       | 0.1722          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.8.md
+++ b/J1J2/square_16_P_0.8.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -40.1494467 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -40.1494467 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.8/ed_netket.sh) |
 | -40.1480758 |       | 0.0463          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -40.1417778 |       | 0.2614          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.85.md
+++ b/J1J2/square_16_P_0.85.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -42.3500589 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -42.3500589 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.85/ed_netket.sh) |
 | -42.3492393 |       | 0.0287          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -42.3390363 |       | 0.3437          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.9.md
+++ b/J1J2/square_16_P_0.9.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -44.5994005 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -44.5994005 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.9/ed_netket.sh) |
 | -44.5949902 |       | 0.1649          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -44.5896339 |       | 0.3595          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_0.95.md
+++ b/J1J2/square_16_P_0.95.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -46.8799267 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -46.8799267 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_0.95/ed_netket.sh) |
 | -46.878747  |       | 0.0488          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -46.8750185 |       | 0.1943          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_16_P_1.0.md
+++ b/J1J2/square_16_P_1.0.md
@@ -1,5 +1,5 @@
 | Energy      | Sigma | Energy Variance | DOF | Einf | Method                                                  | Reference |
 |-------------|-------|-----------------|-----|------|---------------------------------------------------------|-----------|
-| -49.1819609 |       |                 | 16  | 0    | Exact diagonalization                                   | TODO: own code (ED) |
+| -49.1819609 |       |                 | 16  | 0    | Exact diagonalization                                   | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_16_P_1.0/ed_netket.sh) |
 | -49.1808042 |       | 0.0488          | 16  | 0    | VQE + symm. circuit (64 pars., exact grad, statevector) | TODO: ask Nikita |
 | -49.1750881 |       | 0.2689          | 16  | 0    | VQE + symm. circuit (64 pars., 2^14 samples/grad)       | TODO: ask Nikita |

--- a/J1J2/square_36_P_0.3.md
+++ b/J1J2/square_36_P_0.3.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance    | DOF | Einf | Method                       | Reference |
 |--------------------|--------|--------------------|-----|------|------------------------------|-----------|
-| -80.994163118435   |        |                    | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -80.994163118435   |        |                    | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.3/ed_lattice_symmetries.sh) |
 | -80.91180916272728 |        | 1.9377578865160103 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.3/dmrg.sh) |
 | -79.9195           | 0.0035 | 12.5730            | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -79.2055           | 0.0042 | 18.4944            | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/J1J2/square_36_P_0.4.md
+++ b/J1J2/square_36_P_0.4.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance    | DOF | Einf | Method                       | Reference |
 |--------------------|--------|--------------------|-----|------|------------------------------|-----------|
-| -76.283280827996   |        |                    | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -76.283280827996   |        |                    | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.4/ed_lattice_symmetries.sh) |
 | -76.16430367225236 |        | 2.1721936541334794 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.4/dmrg.sh) |
 | -74.8125           | 0.0038 | 15.0651            | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -73.9019           | 0.0046 | 22.0753            | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/J1J2/square_36_P_0.5.md
+++ b/J1J2/square_36_P_0.5.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma   | Energy Variance   | DOF | Einf | Method                                                       | Reference |
 |--------------------|---------|-------------------|-----|------|--------------------------------------------------------------|-----------|
-| -72.548590160286   |         |                   | 36  | 0    | Exact diagonalization                                        | TODO: own code (ED) |
+| -72.548590160286   |         |                   | 36  | 0    | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.5/ed_lattice_symmetries.sh) |
 | -72.54722          | 0.00016 | 0.037(1)          | 36  | 0    | RBM+PP with momentum (K=0), spin-parity (even S), and point-group (A1) projections, 16 hidden units | [paper](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.11.031034) |
 | -72.54140          | 0.00009 | 0.1905(3)         | 36  | 0    | RBM with momentum (K=0), spin-parity (even S), and point-group (A1) projections, 72 hidden units | [paper](https://iopscience.iop.org/article/10.1088/1361-648X/abe268) |
 | -72.167            | 0.003   | 5.42              | 36  | 0    | VMC with projected BCS (Z2 spin liquid)                      | TODO: ask Francesco |

--- a/J1J2/square_36_P_0.6.md
+++ b/J1J2/square_36_P_0.6.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance     | DOF | Einf | Method                       | Reference |
 |--------------------|--------|---------------------|-----|------|------------------------------|-----------|
-| -71.026357467734   |        |                     | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -71.026357467734   |        |                     | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.6/ed_lattice_symmetries.sh) |
 | -70.94811548452927 |        | 0.27765980796630174 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.6/dmrg.sh) |
 | -69.2165           | 0.0021 | 4.37917             | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -68.2285           | 0.0065 | 42.6698             | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/J1J2/square_36_P_0.7.md
+++ b/J1J2/square_36_P_0.7.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance     | DOF | Einf | Method                       | Reference |
 |--------------------|--------|---------------------|-----|------|------------------------------|-----------|
-| -76.320176597454   |        |                     | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -76.320176597454   |        |                     | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.7/ed_lattice_symmetries.sh) |
 | -76.30909588668733 |        | 0.19627705600487386 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.7/dmrg.sh) |
 | -75.9732           | 0.0028 | 7.80946             | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -69.5699           | 0.0083 | 70.6665             | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/J1J2/square_36_P_0.8.md
+++ b/J1J2/square_36_P_0.8.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance    | DOF | Einf | Method                       | Reference |
 |--------------------|--------|--------------------|-----|------|------------------------------|-----------|
-| -84.454070394730   |        |                    | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -84.454070394730   |        |                    | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.8/ed_lattice_symmetries.sh) |
 | -84.35283374817100 |        | 0.9038783749210779 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.8/dmrg.sh) |
 | -84.1270           | 0.0026 | 7.07829            | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -83.0161           | 0.0042 | 18.2412            | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/J1J2/square_36_P_0.9.md
+++ b/J1J2/square_36_P_0.9.md
@@ -1,6 +1,6 @@
 | Energy             | Sigma  | Energy Variance   | DOF | Einf | Method                       | Reference |
 |--------------------|--------|-------------------|-----|------|------------------------------|-----------|
-| -93.463489624054   |        |                   | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -93.463489624054   |        |                   | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.9/ed_lattice_symmetries.sh) |
 | -93.29335086463179 |        | 5.589886989579099 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_0.9/dmrg.sh) |
 | -92.3972           | 0.0047 | 22.1831           | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -91.7305           | 0.0046 | 21.5075           | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/J1J2/square_36_P_1.md
+++ b/J1J2/square_36_P_1.md
@@ -1,6 +1,6 @@
 | Energy              | Sigma  | Energy Variance   | DOF | Einf | Method                       | Reference |
 |---------------------|--------|-------------------|-----|------|------------------------------|-----------|
-| -102.867902314985   |        |                   | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -102.867902314985   |        |                   | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_1/ed_lattice_symmetries.sh) |
 | -102.67869884652434 |        | 7.164533866758574 | 36  | 0    | DMRG (bond dimension = 2048) | [code](https://github.com/varbench/methods/blob/main/scripts/J1J2/square_36_P_1/dmrg.sh) |
 | -102.12601          | 0.0045 | 20.4796           | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -100.82252          | 0.0050 | 25.3075           | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/TFIsing/chain_10_O_1.md
+++ b/TFIsing/chain_10_O_1.md
@@ -1,6 +1,6 @@
 | Energy              | Sigma  | Energy Variance       | DOF | Einf | Method                     | Reference |
 |---------------------|--------|-----------------------|-----|------|----------------------------|-----------|
-| -12.381489999654734 |        |                       | 10  | 0    | Exact Diagonalization      | TODO: own code (ED) |
+| -12.381489999654734 |        |                       | 10  | 0    | Exact Diagonalization      | [code](https://github.com/varbench/methods/blob/main/scripts/TFIsing/chain_10_O_1/ed_netket.sh) |
 | -12.381489999654796 |        | 4.8e-13               | 10  | 0    | DMRG (bond dimension = 13) | [code](https://github.com/varbench/methods/blob/main/scripts/TFIsing/chain_10_O_1/dmrg.sh) |
 | -12.381718          | 2.2e-5 | 0.00049440652         | 10  | 0    | RBM (alpha = 1)            | TODO: own code (RBM) |
 | -12.37844           | 1.9e-4 | 0.03606162            | 10  | 0    | Jastrow baseline           | TODO: own code (Jastrow) |

--- a/TFIsing/square_36_P_3.md
+++ b/TFIsing/square_36_P_3.md
@@ -1,6 +1,6 @@
 | Energy               | Sigma   | Energy Variance        | DOF | Einf | Method                       | Reference |
 |----------------------|---------|------------------------|-----|------|------------------------------|-----------|
-| -115.232707303718485 |         |                        | 36  | 0    | Exact diagonalization        | TODO: own code (ED) |
+| -115.232707303718485 |         |                        | 36  | 0    | Exact diagonalization        | [code](https://github.com/varbench/methods/blob/main/scripts/TFIsing/square_36_P_3/ed_lattice_symmetries.sh) |
 | -115.23270149009103  |         | 0.00029784587604808627 | 36  | 0    | DMRG (bond dimension = 1024) | [code](https://github.com/varbench/methods/blob/main/scripts/TFIsing/square_36_P_3/dmrg.sh) |
 | -115.23165           | 0.00028 | 0.082848699            | 36  | 0    | RBM (alpha = 1)              | TODO: own code (RBM) |
 | -115.19484           | 0.00062 | 0.39779351             | 36  | 0    | Jastrow baseline             | TODO: own code (Jastrow) |

--- a/tV/chain_32_P_16_1.md
+++ b/tV/chain_32_P_16_1.md
@@ -1,6 +1,6 @@
 | Energy              | Sigma | Energy Variance | DOF | Einf              | Method                          | Reference |
 |---------------------|-------|-----------------|-----|-------------------|---------------------------------|-----------|
-| -15.946847944277561 |       |                 | 16  | 7.741935483870968 | Exact diagonalization           | TODO: own code (ED) |
+| -15.946847944277561 |       |                 | 16  | 7.741935483870968 | Exact diagonalization           | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_1/ed_lattice_symmetries.sh) |
 | -15.94684764968563  |       |                 | 16  | 7.741935483870968 | DMRG (maxbonddim = 200)         | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_1/dmrg.sh) |
 | -15.946847944066832 |  | 2.23852225644805e-09 | 16  | 7.741935483870968 | DMRG (maxbonddim = 573)         | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_1/dmrg_B1024.sh) |
 | -15.946206847643403 |       | 1.01e-3         | 16  | 7.741935483870968 | QMC (continuous-time expansion) | [paper](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.93.155117) [code](https://github.com/wangleiphy/SpinlesstV-LCT-INT) |

--- a/tV/chain_32_P_16_2.md
+++ b/tV/chain_32_P_16_2.md
@@ -1,5 +1,5 @@
 | Energy             | Sigma | Energy Variance | DOF | Einf              | Method                          | Reference |
 |--------------------|-------|-----------------|-----|-------------------|---------------------------------|-----------|
-| -12.32869972364372 |       |                 | 16  | 15.48387096774194 | Exact diagonalization           | TODO: own code (ED) |
+| -12.32869972364372 |       |                 | 16  | 15.48387096774194 | Exact diagonalization           | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_2/ed_lattice_symmetries.sh) |
 | -12.32869928774351 |       |                 | 16  | 15.48387096774194 | DMRG (maxbonddim = 200)         | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_2/dmrg.sh) |
 | -12.32494350621494 |       | 5.05e-3         | 16  | 15.48387096774194 | QMC (continuous-time expansion) | [paper](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.93.155117) [code](https://github.com/wangleiphy/SpinlesstV-LCT-INT) |

--- a/tV/chain_32_P_16_4.md
+++ b/tV/chain_32_P_16_4.md
@@ -1,5 +1,5 @@
 | Energy            | Sigma | Energy Variance | DOF | Einf              | Method                          | Reference |
 |-------------------|-------|-----------------|-----|-------------------|---------------------------------|-----------|
-| -7.5021616707610725 |     |                 | 16  | 30.96774193548387 | Exact diagonalization           | TODO: own code (ED) |
+| -7.5021616707610725 |     |                 | 16  | 30.96774193548387 | Exact diagonalization           | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_4/ed_lattice_symmetries.sh) |
 | -7.50216163113578 |       |                 | 16  | 30.96774193548387 | DMRG (maxbonddim = 200)         | [code](https://github.com/varbench/methods/blob/main/scripts/tV/chain_32_P_16_4/dmrg.sh) |
 | -7.48840482444892 |       | 2.05e-2         | 16  | 30.96774193548387 | QMC (continuous-time expansion) | [paper](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.93.155117) [code](https://github.com/wangleiphy/SpinlesstV-LCT-INT) |

--- a/tV/square_16_P_5_0.01.md
+++ b/tV/square_16_P_5_0.01.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf                | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|---------------------|--------------------------------------------------------------|-----------|
-| -11.980026283471341   |                          |                          | 5   | 0.02666666666666667 | Exact diagonalization                                        | TODO: own code (ED) |
+| -11.980026283471341   |                          |                          | 5   | 0.02666666666666667 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_16_P_5_0.01/ed_netket.sh) |
 | -11.980033022886133   | 1.0257481572668477e-05   | 4.303658331496602e-05    | 5   | 0.02666666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz                  | TODO: ask Imelda |
 | -11.98002586610116360 | 1.162693337441909767e-06 | 5.502099642279632244e-07 | 5   | 0.02666666666666667 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |

--- a/tV/square_16_P_5_0.1.md
+++ b/tV/square_16_P_5_0.1.md
@@ -1,6 +1,6 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf               | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|--------------------|--------------------------------------------------------------|-----------|
-| -11.802611098111115   |                          |                          | 5   | 0.2666666666666667 | Exact diagonalization                                        | TODO: own code (ED) |
+| -11.802611098111115   |                          |                          | 5   | 0.2666666666666667 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_16_P_5_0.1/ed_netket.sh) |
 | -11.80259751714968530 | 2.911758083515763256e-05 | 3.954280608127008724e-04 | 5   | 0.2666666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz                  | TODO: ask Imelda |
 | -11.80260628335037687 | 4.409686131925733408e-06 | 8.378069302088285517e-06 | 5   | 0.2666666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -11.80261164187960432 | 4.270607711893185177e-06 | 6.811143292244463681e-06 | 5   | 0.2666666666666667 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |

--- a/tV/square_16_P_5_1.md
+++ b/tV/square_16_P_5_1.md
@@ -1,6 +1,6 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf              | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|-------------------|--------------------------------------------------------------|-----------|
-| -10.240650492312078   |                          |                          | 5   | 2.666666666666667 | Exact diagonalization                                        | TODO: own code (ED) |
+| -10.240650492312078   |                          |                          | 5   | 2.666666666666667 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_16_P_5_1/ed_netket.sh) |
 | -10.23942965693701979 | 1.516009651130502942e-04 | 1.015682635471489362e-02 | 5   | 2.666666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz                  | TODO: ask Imelda |
 | -10.23996190287110863 | 1.403183703273309013e-04 | 7.349369269982601940e-03 | 5   | 2.666666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -10.24062118379990594 | 4.434055779122285710e-05 | 9.009253641658748757e-04 | 5   | 2.666666666666667 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |

--- a/tV/square_16_P_5_10.md
+++ b/tV/square_16_P_5_10.md
@@ -1,6 +1,6 @@
 | Energy                | Sigma                    | Energy Variance      | DOF | Einf              | Method                                                       | Reference |
 |-----------------------|--------------------------|----------------------|-----|-------------------|--------------------------------------------------------------|-----------|
-| -4.052055274410362    |                          |                      | 5   | 26.66666666666667 | Exact diagonalization                                        | TODO: own code (ED) |
+| -4.052055274410362    |                          |                      | 5   | 26.66666666666667 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_16_P_5_10/ed_netket.sh) |
 | -3.778445404182138478 | 3.587246792506795529e-03 | 4.192350206704687388 | 5   | 26.66666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz                  | TODO: ask Imelda |
 | -3.799622351382306640 | 1.925444440896334486e-02 | 8.163303188796383836 | 5   | 26.66666666666667 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -4.017754991800209119 | 2.385759278047703755e-02 | 1.376831362118459134 | 5   | 26.66666666666667 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |

--- a/tV/square_36_P_13_0.01.md
+++ b/tV/square_36_P_13_0.01.md
@@ -1,5 +1,5 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf                | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|---------------------|--------------------------------------------------------------|-----------|
-| -27.933405318364226   |                          |                          | 13  | 0.08914285714285715 | Exact diagonalization                                        | TODO: own code (ED) |
+| -27.933405318364226   |                          |                          | 13  | 0.08914285714285715 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_0.01/ed_lattice_symmetries.sh) |
 | -27.93340661781254397 | 4.794376639741113871e-06 | 8.140955499729786117e-07 | 13  | 0.08914285714285715 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -27.93340599860147933 | 9.830457944288756135e-06 | 2.248973801782667552e-05 | 13  | 0.08914285714285715 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |

--- a/tV/square_36_P_13_0.1.md
+++ b/tV/square_36_P_13_0.1.md
@@ -1,6 +1,6 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf               | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|--------------------|--------------------------------------------------------------|-----------|
-| -27.340544159534836   |                          |                          | 13  | 0.8914285714285715 | Exact diagonalization                                        | TODO: own code (ED) |
+| -27.340544159534836   |                          |                          | 13  | 0.8914285714285715 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_0.1/ed_lattice_symmetries.sh) |
 | -27.34055285498830301 | 5.167570104402214540e-05 | 1.021123460754086199e-04 | 13  | 0.8914285714285715 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -27.340544159534552   | 3.140774396539580678e-06 | 3.615214994693033564e-06 | 13  | 0.8914285714285715 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -27.340535848504246   |                          | 0.000387000677501812     | 13  | 0.8914285714285715 | DMRG (maxbonddim = 4096)                                     | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_0.1/dmrg.sh) |

--- a/tV/square_36_P_13_1.md
+++ b/tV/square_36_P_13_1.md
@@ -1,6 +1,6 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf              | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|-------------------|--------------------------------------------------------------|-----------|
-| -22.07737235783086    |                          |                          | 13  | 8.914285714285715 | Exact diagonalization                                        | TODO: own code (ED) |
+| -22.07737235783086    |                          |                          | 13  | 8.914285714285715 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_1/ed_lattice_symmetries.sh) |
 | -22.01792828440505900 | 3.586025996321709226e-03 | 5.431811628015638105e-01 | 13  | 8.914285714285715 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -22.07494390276825413 | 2.363044827018050196e-04 | 1.782584753629542704e-02 | 13  | 8.914285714285715 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -22.076147854622903   |                          | 0.01800294336391062      | 13  | 8.914285714285715 | DMRG (maxbonddim = 4096)                                     | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_1/dmrg.sh) |

--- a/tV/square_36_P_13_10.md
+++ b/tV/square_36_P_13_10.md
@@ -1,6 +1,6 @@
 | Energy                | Sigma                    | Energy Variance          | DOF | Einf              | Method                                                       | Reference |
 |-----------------------|--------------------------|--------------------------|-----|-------------------|--------------------------------------------------------------|-----------|
-| -7.928026240978371    |                          |                          | 13  | 89.14285714285715 | Exact diagonalization                                        | TODO: own code (ED) |
+| -7.928026240978371    |                          |                          | 13  | 89.14285714285715 | Exact diagonalization                                        | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_10/ed_lattice_symmetries.sh) |
 | -6.168047091994236730 | 8.708582883788365536e-02 | 3.426841426704378790e+01 | 13  | 89.14285714285715 | VMC Determinant Slater-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -7.566606087928786195 | 7.289486653868896063e-03 | 7.919496643390599999e+00 | 13  | 89.14285714285715 | VMC Determinant Slater-Backflow-Jastrow (RBM) Ansatz with K=0 projections (symmetric wrt translations) | TODO: ask Imelda |
 | -7.924461196776301    |                          | 0.12396407883914667      | 13  | 89.14285714285715 | DMRG (maxbonddim = 4096)                                     | [code](https://github.com/varbench/methods/blob/main/scripts/tV/square_36_P_13_10/dmrg.sh) |


### PR DESCRIPTION
They use the naive ED in NetKet for small lattices, and [lattice-symmetries](https://github.com/twesterhout/lattice-symmetries) for larger lattices